### PR TITLE
hack: disable special processing of LFE in aac to fix channel-4 audio

### DIFF
--- a/libavcodec/aacenc.c
+++ b/libavcodec/aacenc.c
@@ -600,7 +600,7 @@ static int aac_encode_frame(AVCodecContext *avctx, AVPacket *avpkt,
             la       = samples2 + (448+64);
             if (!frame)
                 la = NULL;
-            if (tag == TYPE_LFE) {
+            if (0 /*tag == TYPE_LFE*/) {
                 wi[ch].window_type[0] = wi[ch].window_type[1] = ONLY_LONG_SEQUENCE;
                 wi[ch].window_shape   = 0;
                 wi[ch].num_windows    = 1;
@@ -622,7 +622,7 @@ static int aac_encode_frame(AVCodecContext *avctx, AVPacket *avpkt,
             ics->use_kb_window[0]   = wi[ch].window_shape;
             ics->num_windows        = wi[ch].num_windows;
             ics->swb_sizes          = s->psy.bands    [ics->num_windows == 8];
-            ics->num_swb            = tag == TYPE_LFE ? ics->num_swb : s->psy.num_bands[ics->num_windows == 8];
+            ics->num_swb            = 0 /*tag == TYPE_LFE*/ ? ics->num_swb : s->psy.num_bands[ics->num_windows == 8];
             ics->max_sfb            = FFMIN(ics->max_sfb, ics->num_swb);
             ics->swb_offset         = wi[ch].window_type[0] == EIGHT_SHORT_SEQUENCE ?
                                         ff_swb_offset_128 [s->samplerate_index]:
@@ -1000,7 +1000,7 @@ static av_cold int aac_encode_init(AVCodecContext *avctx)
     if (!avctx->bit_rate) {
         for (i = 1; i <= s->chan_map[0]; i++) {
             avctx->bit_rate += s->chan_map[i] == TYPE_CPE ? 128000 : /* Pair */
-                               s->chan_map[i] == TYPE_LFE ? 16000  : /* LFE  */
+                               0 /*s->chan_map[i] == TYPE_LFE*/ ? 16000  : /* LFE  */
                                                             69000  ; /* SCE  */
         }
     }


### PR DESCRIPTION
@ronag This is a hacky fix for https://github.com/nxtedition/nxt/issues/3091 (8 channel distorted audio).

I kept the disabled code in comments so this hack doesn't trip us up in the future.