### PR TITLE
Retry corrupt blocks after EOF / truncation

### DIFF
--- a/libavformat/shared.c
+++ b/libavformat/shared.c
@@ -548,7 +548,7 @@ static int read_cache(SharedContext *s, uint8_t *buf, size_t size, off_t offset)
     while (size) {
         ssize_t ret = pread(s->fd, buf, size, offset);
         if (ret <= 0)
-            return ret ? AVERROR(errno) : AVERROR(EIO);
+            return ret ? AVERROR(errno) : AVERROR_EOF;
         buf    += ret;
         offset += ret;
         size   -= ret;
@@ -633,6 +633,13 @@ retry:
             ret = read_cache(s, tmp, block_size, block_pos);
             if (ret < 0) {
                 av_log(h, AV_LOG_ERROR, "Failed to read from cache file: %s\n", av_err2str(ret));
+                if (ret == AVERROR_EOF) { /* e.g. cache appears truncated? */
+                    if (s->retry_corrupt) {
+                        s->num_corrupt++;
+                        goto read_block;
+                    }
+                    ret = AVERROR(EIO); /* don't propagate EOF to caller */
+                }
                 return ret;
             }
         }

--- a/libavformat/shared.c
+++ b/libavformat/shared.c
@@ -62,6 +62,12 @@
 #define HEADER_MAGIC   MKTAG(u'\xFF', 'S', 'h', '$')
 #define HEADER_VERSION 3
 
+/**
+ * Hard watershed of consecutive failed blocks before we give up on the cache
+ * file altogether and assume it's entirely lost to us.
+ **/
+#define MAX_CORRUPT_BLOCKS 10
+
 static int hash_uri(uint8_t hash[HASH_SIZE], const char *uri)
 {
     struct AVHashContext *ctx = NULL;
@@ -162,6 +168,7 @@ typedef struct SharedContext {
     uint8_t *tmp_buf;
     int block_size;
     int write_err; ///< write error occurred
+    int num_corrupt;
 
     /* cache file */
     uint8_t *cache_data; ///< optional mmap of the cache file
@@ -613,6 +620,9 @@ static int shared_read(URLContext *h, unsigned char *buf, int size)
 retry:
     switch (state) {
     default:
+        if (s->num_corrupt >= MAX_CORRUPT_BLOCKS)
+            goto read_block; /* assume broken cache file */
+
         /* We always need to read the entire block to verify integrity */
         block_size = clamp_size(h, block_size, block_pos); /* filesize may have changed */
         if (s->cache_data) {
@@ -632,10 +642,13 @@ retry:
             av_log(h, AV_LOG_ERROR, "Cache corruption detected for block 0x%"PRIx64" at "
                    "offset 0x%"PRIx64": expected CRC: 0x%08X, got: 0x%08X\n",
                    block_id, block_pos, state, crc);
-            if (s->retry_corrupt)
+            if (s->retry_corrupt) {
+                s->num_corrupt++;
                 goto read_block;
+            }
             return AVERROR(EIO);
-        }
+        } else
+            s->num_corrupt = 0; /* reset corrupt block count on success */
 
         tmp += (ptrdiff_t) offset;
         size = FFMIN(size, block_size - offset);
@@ -657,6 +670,13 @@ retry:
         return AVERROR(EIO);
 
 read_block:
+        if (s->num_corrupt == MAX_CORRUPT_BLOCKS) {
+            av_log(h, AV_LOG_ERROR, "Too many consecutive corrupt blocks; "
+                   "assuming cache file is completely broken.\n");
+            s->num_corrupt++; /* silence this log on subsequent reads */
+        }
+        av_fallthrough;
+
     case BLOCK_NONE:
         if (s->read_only || s->write_err)
             break; /* don't mark block as pending */

--- a/libavformat/shared.c
+++ b/libavformat/shared.c
@@ -660,10 +660,10 @@ read_block:
     case BLOCK_NONE:
         if (s->read_only || s->write_err)
             break; /* don't mark block as pending */
-        if (atomic_compare_exchange_weak_explicit(&block->state, &state,
-                                                  BLOCK_PENDING,
-                                                  memory_order_acquire,
-                                                  memory_order_acquire))
+        if (atomic_compare_exchange_strong_explicit(&block->state, &state,
+                                                    BLOCK_PENDING,
+                                                    memory_order_acquire,
+                                                    memory_order_acquire))
         {
             /* Acquired pending state, proceed to fetch the block */
             acquired = 1;


### PR DESCRIPTION
To avoid the edge case of file truncation / corruption leading to thousands of errors being spammed, I also added a hard-coded limit (10) of corrupt blocks to encounter before we just assume that the rest of the file is corrupt as well.

This could maybe be tunable as e.g. the parameter to `-retry_corrupt N`, but that could in theory break existing users besides nxtedition.